### PR TITLE
General maintenance of reqwire

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,6 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
 install: pip install python-coveralls tox-travis
 script: tox

--- a/mypy.ini
+++ b/mypy.ini
@@ -6,4 +6,5 @@ warn_unused_ignores = True
 [mypy-src/reqwire/*]
 disallow_untyped_calls = True
 disallow_untyped_defs = True
-silent_imports = True
+ignore_missing_imports = True
+follow_imports = skip

--- a/requirements/lck/docs.txt
+++ b/requirements/lck/docs.txt
@@ -6,33 +6,33 @@
 #
 #    pip-compile --output-file /tmp/tmpVe8OI6 requirements/src/docs.in
 #
-alabaster==0.7.9          # via sphinx
+alabaster==0.7.10         # via sphinx
 atomicwrites==1.1.5
 attrdict==2.0.0           # via biome
-babel==2.3.4              # via sphinx
+babel==2.4.0              # via sphinx
 biome==0.1.3
-click==6.6                # via pip-tools
+click==6.7                # via pip-tools
 docutils==0.13.1          # via sphinx
 emoji==0.3.9
 enum34==1.1.6
 fasteners==0.14.1
 first==2.0.1              # via pip-tools
 imagesize==0.7.1          # via sphinx
-Jinja2==2.8               # via sphinx
-MarkupSafe==0.23          # via jinja2
-monotonic==1.2            # via fasteners
+jinja2==2.9.6             # via sphinx
+markupsafe==1.0           # via jinja2
+monotonic==1.3            # via fasteners
 ordered-set==2.0.1
 pathlib2==2.1.0
 pathlib==1.0.1            # via biome
-pip-tools==1.8.0
-pockets==0.3.1            # via sphinxcontrib-napoleon
-Pygments==2.1.3           # via sphinx
-pytz==2016.10             # via babel
+pip-tools==1.9.0
+pockets==0.3.2            # via sphinxcontrib-napoleon
+pygments==2.2.0           # via sphinx
+pytz==2017.2              # via babel
 requests==2.12.3
 sh==1.12.7
 six==1.10.0               # via attrdict, fasteners, pathlib2, pip-tools, pockets, sphinx, sphinxcontrib-napoleon
 snowballstemmer==1.2.1    # via sphinx
 sphinx-md-theme==0.1a4
-Sphinx==1.5
+sphinx==1.5
 sphinxcontrib-napoleon==0.6.0
 typing==3.5.2.2

--- a/requirements/lck/main.txt
+++ b/requirements/lck/main.txt
@@ -9,16 +9,16 @@
 atomicwrites==1.1.5
 attrdict==2.0.0           # via biome
 biome==0.1.3
-click==6.6                # via pip-tools
+click==6.7                # via pip-tools
 emoji==0.3.9
 enum34==1.1.6
 fasteners==0.14.1
 first==2.0.1              # via pip-tools
-monotonic==1.2            # via fasteners
+monotonic==1.3            # via fasteners
 ordered-set==2.0.1
 pathlib2==2.1.0
 pathlib==1.0.1            # via biome
-pip-tools==1.8.0
+pip-tools==1.9.0
 requests==2.12.3
 sh==1.12.7
 six==1.10.0               # via attrdict, fasteners, pathlib2, pip-tools

--- a/requirements/lck/qa.txt
+++ b/requirements/lck/qa.txt
@@ -6,8 +6,6 @@
 #
 #    pip-compile --output-file /tmp/tmp2eVvBE requirements/src/qa.in
 #
-configparser==3.5.0       # via flake8
-enum34==1.1.6             # via flake8
 flake8-blind-except==0.1.1
 flake8-commas==0.1.6
 flake8-comprehensions==1.2.1
@@ -22,6 +20,3 @@ pep8==1.7.0               # via flake8-commas
 pycodestyle==2.2.0        # via flake8, flake8-import-order
 pydocstyle==1.1.1         # via flake8-docstrings
 pyflakes==1.3.0           # via flake8
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools                # via flake8-blind-except

--- a/requirements/lck/test.txt
+++ b/requirements/lck/test.txt
@@ -9,28 +9,25 @@
 atomicwrites==1.1.5
 attrdict==2.0.0           # via biome
 biome==0.1.3
-click==6.6                # via pip-tools
+click==6.7                # via pip-tools
 cookies==2.2.1            # via responses
-coverage==4.2             # via pytest-cov
+coverage==4.3.4           # via pytest-cov
 emoji==0.3.9
 enum34==1.1.6
 fasteners==0.14.1
 first==2.0.1              # via pip-tools
-funcsigs==1.0.2           # via mock
 future==0.16.0
-mock==2.0.0               # via pytest-mock, responses
-monotonic==1.2            # via fasteners
+monotonic==1.3            # via fasteners
 ordered-set==2.0.1
 pathlib2==2.1.0
 pathlib==1.0.1            # via biome
-pbr==1.10.0               # via mock
-pip-tools==1.8.0
-py==1.4.32                # via pytest
+pip-tools==1.9.0
+py==1.4.33                # via pytest
 pytest-cov==2.4.0
 pytest-mock==1.5.0
-pytest==3.0.5             # via pytest-cov, pytest-mock
+pytest==3.0.7             # via pytest-cov, pytest-mock
 requests==2.12.3
 responses==0.5.1
 sh==1.12.7
-six==1.10.0               # via attrdict, fasteners, mock, pathlib2, pip-tools, responses
+six==1.10.0               # via attrdict, fasteners, pathlib2, pip-tools, responses
 typing==3.5.2.2

--- a/requirements/src/main.in
+++ b/requirements/src/main.in
@@ -9,7 +9,7 @@ enum34==1.1.6
 fasteners==0.14.1
 ordered-set==2.0.1
 pathlib2==2.1.0
-pip-tools==1.8.0
+pip-tools==1.9.0
 requests==2.12.3
 sh==1.12.7
 typing==3.5.2.2

--- a/src/reqwire/cli.py
+++ b/src/reqwire/cli.py
@@ -285,8 +285,8 @@ def main_remove(ctx,
             hireq = (reqwire.helpers.requirements.HashableInstallRequirement
                      .from_line(specifier))
             for requirement in req_file.requirements:
-                src_req_name = piptools.utils.name_from_req(requirement)
-                target_req_name = piptools.utils.name_from_req(hireq)
+                src_req_name = requirement.name
+                target_req_name = hireq.name
                 if src_req_name == target_req_name:
                     req_file.requirements.remove(requirement)
                     console.info('removed "{}" from {}',

--- a/src/reqwire/helpers/requirements.py
+++ b/src/reqwire/helpers/requirements.py
@@ -30,7 +30,7 @@ import six.moves
 
 MYPY = False
 if MYPY:  # pragma: no cover
-    from typing import Any, Iterable, Optional, Set, Tuple  # noqa: F401
+    from typing import Any, Iterable, List, Optional, Set, Tuple  # noqa: F401
 
     InstallReqIterable = Iterable['HashableInstallRequirement']
     InstallReqSet = Set['HashableInstallRequirement']
@@ -214,6 +214,7 @@ class RequirementFile(object):
         """A Python package index URL."""
         if len(self.index_urls):
             return self.index_urls[0]
+        return None
 
     @property
     def extra_index_urls(self):

--- a/src/reqwire/helpers/requirements.py
+++ b/src/reqwire/helpers/requirements.py
@@ -387,13 +387,12 @@ def build_pip_session(*args):
     return pip_options, session
 
 
-def format_requirement(ireq, include_specifier=True):
+def format_requirement(ireq, marker=None):
     # type: (HashableInstallRequirement, bool) -> str
     if ireq.editable and ireq.source_dir.startswith('.'):
         return '-e {}'.format(ireq.source_dir)
     else:
-        return piptools.utils.format_requirement(
-            ireq, include_specifier=include_specifier)
+        return piptools.utils.format_requirement(ireq, marker=marker)
 
 
 def get_canonical_name(package_name, index_urls=None, *args):

--- a/tests/unit/helpers/test_cli.py
+++ b/tests/unit/helpers/test_cli.py
@@ -77,3 +77,9 @@ def test_build_with_pip_compile_options(cli_runner, mocker):
     result = cli_runner.invoke(main, ['build', '-t', 'main', '--', '--no-header'])
     assert result.exit_code == 0, result.output
     assert pip_compile.call_args[0][2] == '--no-header'
+
+
+def test_main_remove(cli_runner):
+    from reqwire.cli import main
+    result = cli_runner.invoke(main, ['remove', 'Flask'])
+    assert result.exit_code == 0, result.output

--- a/tests/unit/helpers/test_cli.py
+++ b/tests/unit/helpers/test_cli.py
@@ -2,10 +2,6 @@
 from __future__ import absolute_import
 
 import sh
-import builtins
-import sys
-
-import six
 
 import reqwire.helpers.cli
 
@@ -36,7 +32,7 @@ def test_emojize_linux(mocker):
 
 def test_emojize_linux_ioerror(mocker):
     mocker.patch('sys.platform', 'linux')
-    io_open = mocker.patch('io.open', side_effect=IOError)
+    mocker.patch('io.open', side_effect=IOError)
     assert reqwire.helpers.cli.emojize(
         ':thumbs_up_sign:').encode('utf-8') == b'\xf0\x9f\x91\x8d'
 
@@ -46,7 +42,7 @@ def test_emojize_wsl(mocker):
     mocker.patch('io.open', mocker.mock_open(
         read_data='Linux version 3.4.0-Microsoft (Microsoft@Microsoft.com)'))
     assert reqwire.helpers.cli.emojize(
-        ':thumbs_up_sign: foo').encode('utf-8')  == b'foo'
+        ':thumbs_up_sign: foo').encode('utf-8') == b'foo'
 
 
 def test_console_writer_quiet(mocker):
@@ -74,7 +70,8 @@ def test_console_writer_verbose(mocker):
 def test_build_with_pip_compile_options(cli_runner, mocker):
     from reqwire.cli import main
     pip_compile = mocker.patch.object(sh, 'pip_compile')
-    result = cli_runner.invoke(main, ['build', '-t', 'main', '--', '--no-header'])
+    result = cli_runner.invoke(main, ['build', '-t', 'main', '--',
+                                      '--no-header'])
     assert result.exit_code == 0, result.output
     assert pip_compile.call_args[0][2] == '--no-header'
 

--- a/tests/unit/helpers/test_requirements.py
+++ b/tests/unit/helpers/test_requirements.py
@@ -60,3 +60,9 @@ def test_resolve_specifier_wihout_resolve_versions(ireq):
     requirement = reqwire.helpers.requirements.resolve_specifier(
         'reqwire', resolve_versions=False)
     assert not requirement.is_pinned
+
+
+def test_build_ireq_set():
+    specifiers = ['Flask']
+    result = reqwire.helpers.requirements.build_ireq_set(specifiers)
+    assert result

--- a/tests/unit/test_scaffold.py
+++ b/tests/unit/test_scaffold.py
@@ -1,5 +1,3 @@
-import datetime
-
 import pathlib
 import pip.models
 import pip.req

--- a/tests/unit/test_scaffold.py
+++ b/tests/unit/test_scaffold.py
@@ -43,13 +43,13 @@ def test_extend_source_file(mocker, tmpdir):
     src_dir = tmpdir.mkdir('src')
     src_file = src_dir.join('requirements.in')
     with mocker.patch('reqwire.helpers.requirements.resolve_specifier',
-            return_value=pip.req.InstallRequirement.from_line(
-                'Flask==0.11.1')):
+                      return_value=pip.req.InstallRequirement.from_line(
+                          'Flask==0.11.1')):
         reqwire.scaffold.extend_source_file(
             working_directory=str(tmpdir),
             tag_name='requirements',
             specifiers=['flask'])
-        assert 'Flask==0.11.1' in src_file.read()
+        assert 'flask==0.11.1' in src_file.read()
 
 
 def test_init_source_dir(tmpdir):

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ import-order-style = google
 max-complexity = 11
 
 [tox]
-envlist = cov-init,py27,py33,py34,py35,py35-mypy,py35-lint,cov-report
+envlist = cov-init,py{27,33,34,35,36},py35-{mypy,lint},cov-report
 
 [testenv]
 usedevelop = true
@@ -40,6 +40,7 @@ basepython =
   py33: python3.3
   py34: python3.4
   py35: python3.5
+  py36: python3.6
 deps =
   -rrequirements/lck/test.txt
 setenv =
@@ -85,3 +86,4 @@ python =
   3.3: py33
   3.4: py34
   3.5: cov-init, py35, py35-{lint,mypy}, cov-report
+  3.6: py36

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ envlist = cov-init,py{27,33,34,35,36},py35-{mypy,lint},cov-report
 
 [testenv]
 usedevelop = true
-commands = py.test --cov --cov-report= {posargs}
+commands = pytest --cov --cov-report= {posargs}
 basepython =
   cov-{init,report}: python3.5
   py27: python2.7

--- a/tox.ini
+++ b/tox.ini
@@ -73,9 +73,9 @@ deps =
 
 [testenv:py35-mypy]
 commands =
-  mypy -s --fast-parser src/reqwire
+  mypy --ignore-missing-imports --follow-imports=skip --fast-parser src/reqwire
 deps =
-  mypy-lang>=0.4
+  mypy
   typed-ast
 setenv =
   MYPYPATH = src/stubs


### PR DESCRIPTION
- piptools1.9+
- update packages
- test against python3.6
- linter cleanups

This will require a major version bump change, as it breaks backward compatibility.