### PR TITLE
Add support for remote editable link

### DIFF
--- a/src/reqwire/helpers/requirements.py
+++ b/src/reqwire/helpers/requirements.py
@@ -390,8 +390,12 @@ def build_pip_session(*args):
 
 def format_requirement(ireq, marker=None):
     # type: (HashableInstallRequirement, bool) -> str
-    if ireq.editable and ireq.source_dir.startswith('.'):
-        return '-e {}'.format(ireq.source_dir)
+    if ireq.editable:
+        if ireq.source_dir and ireq.source_dir.startswith('.'):
+            return '-e {}'.format(ireq.source_dir)
+        if ireq.link:
+            return '-e {}'.format(ireq.link)
+        raise NotImplementedError('Unknown type of editable requirement')
     else:
         return piptools.utils.format_requirement(ireq, marker=marker)
 

--- a/tests/unit/helpers/test_requirements.py
+++ b/tests/unit/helpers/test_requirements.py
@@ -1,3 +1,5 @@
+import os
+
 import pip.exceptions
 import pip.models
 import pip.req
@@ -66,3 +68,13 @@ def test_build_ireq_set():
     specifiers = ['Flask']
     result = reqwire.helpers.requirements.build_ireq_set(specifiers)
     assert result
+
+
+@pytest.mark.parametrize('req,expected', [
+    ('-e git+https://github.com/darvid/reqwire.git@master#egg=reqwire',
+     '-e git+https://github.com/darvid/reqwire.git@master#egg=reqwire'),
+    ('-e .', '-e file://{}'.format(os.path.abspath(os.path.dirname('.')))),
+])
+def test_format_requirement(req, expected):
+    ireq = reqwire.helpers.requirements.HashableInstallRequirement.from_line(req)  # noqa
+    assert reqwire.helpers.requirements.format_requirement(ireq) == expected


### PR DESCRIPTION
example:
```
-e git+https://github.com/darvid/reqwire.git@master#egg=reqwire
```